### PR TITLE
商品検索Lv1の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ gem 'json'
 gem 'gretel'
 gem 'gon'
 gem 'fog-aws'
-
 gem 'pry-rails'
 gem 'dotenv-rails'
 gem 'gretel'

--- a/app/assets/stylesheets/modules/items.scss
+++ b/app/assets/stylesheets/modules/items.scss
@@ -24,15 +24,14 @@
         &__logo{
           height: 50px;
           width: 140px;
-          margin-right: 30px;;
+          margin-right: 30px;
           padding-bottom: 10px;
-          // background-color: pink;
         }
         &__search{
-          height: 36px;
+          height: 38px;
           width: 834px;
           margin-bottom: 5px;
-          // background-color: yellow;
+          border: 1px solid #eee;
           position: relative;
           &__box{
             height: 36px;
@@ -49,9 +48,7 @@
           &__faicon{
             height: 36px;
             width: 36px;
-            padding: 2px 8px 8px;
-            // padding-top: 2px;
-            // padding-right: 8px;
+            padding-top:8px;
             background-color: #3ccace;
             position: absolute;
             top: 0;
@@ -395,5 +392,27 @@
     margin: 0 auto;
     width: 100%;
     height: 50px;
+  }
+}
+
+.search-box{
+  .search-main{
+    &__container{
+      &__head{
+        font-size: 1.5em;
+        font-weight: bold;
+      }
+    &__items-box{
+      padding-top:10px;
+      &__head{
+        font-size: 1.3em;
+        font-weight: bold;
+      }
+      &__lists{
+        display: flex;
+        align-items: flex-start;
+      }
+    }
+    }
   }
 }

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -2,6 +2,7 @@ class CardsController < ApplicationController
   require "payjp"
   before_action :set_card,only: [:show,:delete]
   before_action :set_user,only: [:new,:pay,:delete,:show]
+  before_action :set_search
 
   def new
     card = Card.where(user_id: current_user.id)
@@ -49,6 +50,11 @@ class CardsController < ApplicationController
       customer = Payjp::Customer.retrieve(@cards.customer_id)
       @default_card_information = customer.cards.retrieve(@cards.card_id)
     end
+  end
+
+  def set_search
+    @search = Item.ransack(params[:q]) 
+    @search_items = @search.result(distinct: true)
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   require 'payjp'
   before_action :set_card,only: [:purchase, :pay]
   before_action :set_item,only: [:purchase, :pay]
+  before_action :set_search
 
   def index
     @items = Item.all.page(params[:page]).order("created_at DESC").per(10)
@@ -104,6 +105,14 @@ class ItemsController < ApplicationController
   end
 
   def done
+  end
+
+  def search
+  end
+
+  def set_search
+    @search = Item.ransack(params[:q]) 
+    @search_items = @search.result(distinct: true)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,14 @@
 class UsersController < ApplicationController
+  before_action :set_search
+
   def edit
   end
+  
   def update
   end  
+
+  def set_search
+    @search = Item.ransack(params[:q]) 
+    @search_items = @search.result(distinct: true)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,4 +14,5 @@ class Item < ApplicationRecord
     validates :category, presence: { message: 'カテゴリーを選択してください' }
   has_many :comments
   accepts_nested_attributes_for :photos
+  scope :searches, -> (search){where('name LIKE(?)', "%#{search}%")}
 end

--- a/app/views/items/_headder.html.haml
+++ b/app/views/items/_headder.html.haml
@@ -5,10 +5,11 @@
         .h-header__extra__frame__upper__logo
           =link_to image_tag('http://furima.tokyo/assets/logo-d3d78326971d78b06e3d6f0ba666d025a8ad681286b4d9e00e7dbe8673bcfd23.svg', size: "140x40"), root_path
         .h-header__extra__frame__upper__search
-          .h-header__extra__frame__upper__search__box
-            %input{:placeholder => "キーワードから探す", :type => 'text'}
-          .h-header__extra__frame__upper__search__faicon
-            =link_to image_tag('http://furima.tokyo/assets/icon-search-60a83ada85216fe00789cd16065281694d9a08948275fef83683fadcf131d84d.svg', size: "20x20"), '#'
+          = search_form_for @search, url: search_items_path do |f|
+            = f.text_field :name_cont , placeholder: "キーワードから探す", class: 'h-header__extra__frame__upper__search__box'
+            = button_tag type: 'submit', class: 'search__button' do
+              .h-header__extra__frame__upper__search__faicon
+                = image_tag('http://furima.tokyo/assets/icon-search-60a83ada85216fe00789cd16065281694d9a08948275fef83683fadcf131d84d.svg', size: "20x20")
       .h-header__extra__frame__lower
         .h-header__extra__frame__lower__left
           .h-header__extra__frame__lower__left__category

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,25 @@
+.wrapper
+  = render "items/headder"
+  .search-box
+    .search-main
+      .search-main__container
+        .search-main__container__head
+          キーワード検索
+        .search-main__container__items-box
+          .search-main__container__items-box__head
+            検索結果
+        .search-main__container__items-box__lists
+          - @search_items.each do |item|
+            .h-main__frame__group__cont__lists__list
+              .h-main__frame__group__cont__lists__list__leaf
+                = link_to item_path(item) do
+                  .h-main__frame__group__cont__lists__list__leaf__pic
+                    - item.photos.each_with_index do |n|
+                      =image_tag n.image.url, size: "188x188"
+                      -break if i=0
+                    .h-main__frame__group__cont__lists__list__leaf__pic__price
+                      = "¥#{item.price}"
+                  .h-main__frame__group__cont__lists__list__leaf__comment
+                    = item.name
+          -# = paginate(@items)
+  = render "items/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
       post 'pay', to:'items#pay'
       get 'done', to:'items#done'
     end
+    collection do
+      get 'search', to: 'items#search'
+    end
   end
 
   resources :users, only: [:edit, :update] do


### PR DESCRIPTION
# What 
商品をキーワードであいまい検索ができるようにする
検索結果を表示する

動作確認：https://gyazo.com/651282c29a4d5c42e7382e0e1e465b53

# Why
商品名があいまいでも検索がかけられることにより、ユーザーがより多くのアイテムをチェックできるようにするため